### PR TITLE
Make keywords more readable

### DIFF
--- a/_sass/_syntax.scss
+++ b/_sass/_syntax.scss
@@ -23,7 +23,7 @@
     .kd    { color: #C776DF; font-weight: bold } // Keyword.Declaration
     .kp    { font-weight: bold } // Keyword.Pseudo
     .kr    { font-weight: bold } // Keyword.Reserved
-    .kt    { color: #458; font-weight: bold } // Keyword.Type
+    .kt    { color: #8C8FE7; font-weight: bold } // Keyword.Type
     .m     { color: #4FB6C3 } // Literal.Number
     .s     { color: #A2BD40 } // Literal.String
     .na    { color: #E2964A } // Name.Attribute


### PR DESCRIPTION
Hi Majid,

Love your blog and I'm an avid reader. Unfortunately the color you chose for keywords is very hard to read on the black background. This PR adjust the text color to be more readable on your dark background.

## Before
![Screen Shot 2020-09-02 at 10 57 36 AM](https://user-images.githubusercontent.com/13894518/92019608-bd9fa180-ed0b-11ea-8362-fec034625dde.png)

## After
![Screen Shot 2020-09-02 at 10 57 59 AM](https://user-images.githubusercontent.com/13894518/92019611-c1cbbf00-ed0b-11ea-940c-8e69dc267f6f.png)
